### PR TITLE
Reimbursement grant type for saving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dk.lmst.ctr</groupId>
     <artifactId>ctr-schemas</artifactId>
-    <version>1.1.15</version>
+    <version>1.1.16</version>
     <name>ctr-schemas</name>
     <description>CTR schemas</description>
     <packaging>pom</packaging>

--- a/src/schemas/2022/12/01/CreateReimbursementGrantRequest.xsd
+++ b/src/schemas/2022/12/01/CreateReimbursementGrantRequest.xsd
@@ -5,7 +5,7 @@
 		elementFormDefault="qualified">
 
 	<include schemaLocation="PersonIdentifier.xsd"/>	
-	<include schemaLocation="ReimbursementGrant.xsd"/>
+	<include schemaLocation="SaveReimbursementGrant.xsd"/>
 
 	<element name="CreateReimbursementGrantRequest">
 		<annotation>
@@ -15,7 +15,7 @@
 		<complexType>
 			<sequence>
 				<element name="PersonIdentifier" type="ctr:PersonIdentifierType"/>
-				<element name="ReimbursementGrant" type="ctr:ReimbursementGrantType"/>
+				<element name="ReimbursementGrant" type="ctr:SaveReimbursementGrantType"/>
 			</sequence>
 		</complexType>
 	</element>

--- a/src/schemas/2022/12/01/RouteOfAdministrationText.xsd
+++ b/src/schemas/2022/12/01/RouteOfAdministrationText.xsd
@@ -6,14 +6,14 @@
 		attributeFormDefault="unqualified">
 	<element name="RouteOfAdministrationText" type="ctr:RouteOfAdministrationTextType">
 		<annotation>
-			<documentation xml:lang="en-GB">Indicates the formulations route of administration</documentation>
-			<documentation xml:lang="da-DK">Angiver medicinens administrationsvej</documentation>
+			<documentation xml:lang="en-GB">Intended for the formulations route of administration. There is no validation of data, and the field has been used inconsistently, e.g. for dosage form</documentation>
+			<documentation xml:lang="da-DK">Har til hensigt at angive medicinens administrationsvej. Der er ikke validering af data, og feltet er blevet brugt inkonsistent, eks. til doseringsform</documentation>
 		</annotation>
 	</element>
 	<simpleType name="RouteOfAdministrationTextType">
 		<restriction base="string">
 			<minLength value="1"/>
-			<maxLength value="50"/>
+			<maxLength value="15"/>
 		</restriction>
 	</simpleType>
 </schema>

--- a/src/schemas/2022/12/01/SaveReimbursementGrant.xsd
+++ b/src/schemas/2022/12/01/SaveReimbursementGrant.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+		xmlns:ctr="http://lmst.dk/ctr/xml.schema/2022/12/01"
+		targetNamespace="http://lmst.dk/ctr/xml.schema/2022/12/01"
+		elementFormDefault="qualified">
+
+    <include schemaLocation="ValidFromDate.xsd"/>
+	<include schemaLocation="ValidToDate.xsd"/>
+    <include schemaLocation="ReimbursementGrantType.xsd"/>
+    <include schemaLocation="ATC.xsd"/>
+    <include schemaLocation="JournalNumber.xsd"/>
+    <include schemaLocation="PackageNumber.xsd"/>
+    <include schemaLocation="RouteOfAdministration.xsd"/>
+    <include schemaLocation="CreatedDateTime.xsd"/>
+    <include schemaLocation="DrugName.xsd"/>
+    
+	<element name="SaveReimbursementGrant" type="ctr:SaveReimbursementGrantType">
+		<annotation>
+			<documentation xml:lang="en-GB">Description of a CTR reimbursement grant</documentation>
+			<documentation xml:lang="da-DK">Beskrivelse af en CTR bevilling</documentation>
+		</annotation>
+	</element>
+	<complexType name="SaveReimbursementGrantType">
+		<sequence>
+            <element name="Type" type="ctr:ReimbursementGrantTypeType" />
+            <element name="ValidFromDate" type="ctr:ValidFromDateType"/>
+            <element name="ValidToDate" type="ctr:ValidToDateType" minOccurs="0"/>
+            <element name="ATCCode" type="ctr:ATCCodeType" minOccurs="0"/>
+            <element name="RouteOfAdministrationText" type="ctr:RouteOfAdministrationTextType" minOccurs="0"/>
+            <element name="DrugName" type="ctr:DrugNameType" minOccurs="0"/>
+            <element name="PackageNumber" type="ctr:PackageNumberType" minOccurs="0"/>
+            <element name="JournalNumber" type="ctr:JournalNumberType"/>
+            <element name="CreatedDateTime" type="ctr:CreatedDateTimeType"/>
+		</sequence>
+	</complexType>
+</schema>

--- a/src/schemas/2022/12/01/UpdateReimbursementGrantRequest.xsd
+++ b/src/schemas/2022/12/01/UpdateReimbursementGrantRequest.xsd
@@ -5,7 +5,7 @@
 		elementFormDefault="qualified">
 
 	<include schemaLocation="PersonIdentifier.xsd"/>	
-	<include schemaLocation="ReimbursementGrant.xsd"/>
+	<include schemaLocation="SaveReimbursementGrant.xsd"/>
 
 	<element name="UpdateReimbursementGrantRequest">
 		<annotation>
@@ -15,7 +15,7 @@
 		<complexType>
 			<sequence>
 				<element name="PersonIdentifier" type="ctr:PersonIdentifierType"/>
-				<element name="ReimbursementGrant" type="ctr:ReimbursementGrantType"/>
+				<element name="ReimbursementGrant" type="ctr:SaveReimbursementGrantType"/>
 			</sequence>
 		</complexType>
 	</element>


### PR DESCRIPTION
- Separate the types for getting and saving reimbursement grants. Only support data which is actually written in the save request (for example, do not allow sending ATC.Text, which isn't persisted, and would disappear on a round-trip).